### PR TITLE
Add uniform grid accelerator

### DIFF
--- a/src/pbrt/cpu/aggregates.h
+++ b/src/pbrt/cpu/aggregates.h
@@ -104,6 +104,34 @@ class KdTreeAggregate {
     Bounds3f bounds;
 };
 
+// GridAggregate Definition
+class GridAggregate {
+  public:
+    GridAggregate(std::vector<Primitive> p);
+
+    static GridAggregate *Create(std::vector<Primitive> prims,
+                                 const ParameterDictionary &parameters);
+
+    Bounds3f Bounds() const { return bounds; }
+
+    pstd::optional<ShapeIntersection> Intersect(const Ray &ray, Float tMax) const;
+
+    bool IntersectP(const Ray &ray, Float tMax) const;
+
+  private:
+    int posToVoxel(const Point3f &p, int axis) const;
+    Float voxelToPos(int p, int axis) const;
+    int offset(int x, int y, int z) const {
+        return z * nVoxels[0] * nVoxels[1] + y * nVoxels[0] + x;
+    }
+
+    std::vector<Primitive> primitives;
+    int nVoxels[3] = {0, 0, 0};
+    Bounds3f bounds;
+    Vector3f width, invWidth;
+    std::vector<std::vector<int>> voxels;
+};
+
 }  // namespace pbrt
 
 #endif  // PBRT_CPU_AGGREGATES_H

--- a/src/pbrt/cpu/primitive.h
+++ b/src/pbrt/cpu/primitive.h
@@ -28,11 +28,12 @@ class TransformedPrimitive;
 class AnimatedPrimitive;
 class BVHAggregate;
 class KdTreeAggregate;
+class GridAggregate;
 
 // Primitive Definition
 class Primitive
     : public TaggedPointer<SimplePrimitive, GeometricPrimitive, TransformedPrimitive,
-                           AnimatedPrimitive, BVHAggregate, KdTreeAggregate> {
+                           AnimatedPrimitive, BVHAggregate, KdTreeAggregate, GridAggregate> {
   public:
     // Primitive Interface
     using TaggedPointer::TaggedPointer;


### PR DESCRIPTION
## Summary
- implement `GridAggregate` as a uniform grid accelerator
- support creating accelerator with `Accelerator "grid"`
- allow primitives to reference the new aggregate

## Testing
- `cmake .. -DPBRT_USE_PREGENERATED_RGB_TO_SPECTRUM_TABLES=True` *(fails: submodule isn't up to date)*

------
https://chatgpt.com/codex/tasks/task_b_684162afbe208333b9d4a2e5a1dae1cc