### PR TITLE
Add wavelength storage and checks to SampledSpectrum

### DIFF
--- a/src/pbrt/util/spectrum.cpp
+++ b/src/pbrt/util/spectrum.cpp
@@ -162,8 +162,10 @@ std::string BlackbodySpectrum::ToString() const {
     return StringPrintf("[ BlackbodySpectrum T: %f ]", T);
 }
 
-PBRT_CPU_GPU SampledSpectrum ConstantSpectrum::Sample(const SampledWavelengths &) const {
-    return SampledSpectrum(c);
+PBRT_CPU_GPU SampledSpectrum ConstantSpectrum::Sample(const SampledWavelengths &lambda) const {
+    SampledSpectrum s(c);
+    s.SetWavelengths(lambda);
+    return s;
 }
 
 std::string ConstantSpectrum::ToString() const {


### PR DESCRIPTION
## Summary
- track wavelengths and PDFs in `SampledSpectrum`
- copy wavelengths when sampling spectra
- assert when combining spectra with mismatched wavelengths

## Testing
- `cmake -B build -S .` *(fails: submodules not updated)*

------
https://chatgpt.com/codex/tasks/task_b_684ddbaddafc8333ab711a743529b02a