### PR TITLE
Disable SQL logging via macro

### DIFF
--- a/src/pbrt/util/spectrum.cpp
+++ b/src/pbrt/util/spectrum.cpp
@@ -24,7 +24,7 @@
 #include <algorithm>
 #include <cmath>
 #include <map>
-#ifndef PBRT_IS_GPU_CODE
+#if defined(PBRT_ENABLE_SQL) && !defined(PBRT_IS_GPU_CODE)
 #include <mysql/mysql.h>
 #endif
 
@@ -2850,7 +2850,7 @@ std::string FindMatchingNamedSpectrum(Spectrum s) {
     return "";
 }
 
-#ifndef PBRT_IS_GPU_CODE
+#if defined(PBRT_ENABLE_SQL) && !defined(PBRT_IS_GPU_CODE)
 void LogSpectrumAssert(const char *file, int line, const char *tag, Float a,
                        Float b) {
     MYSQL *conn = mysql_init(nullptr);

--- a/src/pbrt/util/spectrum.h
+++ b/src/pbrt/util/spectrum.h
@@ -27,13 +27,13 @@
 #include <numeric>
 #include <string>
 #include <vector>
-#ifndef PBRT_IS_GPU_CODE
+#if defined(PBRT_ENABLE_SQL) && !defined(PBRT_IS_GPU_CODE)
 #include <mysql/mysql.h>
 #endif
 
 namespace pbrt {
 
-#ifndef PBRT_IS_GPU_CODE
+#if defined(PBRT_ENABLE_SQL) && !defined(PBRT_IS_GPU_CODE)
 void LogSpectrumAssert(const char *file, int line, const char *tag, Float a,
                        Float b);
 


### PR DESCRIPTION
## Summary
- add PBRT_ENABLE_SQL to conditionally compile SQL logging code

## Testing
- `cmake -B build -S . -DPBRT_BUILD_GPU_RENDERER=OFF -DGIT_EXECUTABLE=/bin/false` *(fails: add_subdirectory given source "src/build" which is not an existing directory)*

------
https://chatgpt.com/codex/tasks/task_b_684fd286cd148333b7359cd74fbb7f33